### PR TITLE
update gan.py

### DIFF
--- a/gan.py
+++ b/gan.py
@@ -89,7 +89,7 @@ def train():
     d_trainer = optimizer.minimize(d_loss, var_list=d_params)
     g_trainer = optimizer.minimize(g_loss, var_list=g_params)
 
-    init = tf.initialize_all_variables()
+    init = tf.global_variables_initializer()
 
     saver = tf.train.Saver()
 
@@ -132,7 +132,7 @@ def test():
     x_generated, _ = build_generator(z_prior)
     chkpt_fname = tf.train.latest_checkpoint(output_path)
 
-    init = tf.initialize_all_variables()
+    init = tf.global_variables_initializer()
     sess = tf.Session()
     saver = tf.train.Saver()
     sess.run(init)


### PR DESCRIPTION
initialize_all_variables (from tensorflow.python.ops.variables) is
deprecated and will be removed after 2017-03-02.
Instructions for updating:
Use `tf.global_variables_initializer` instead.